### PR TITLE
fix: fetch libeigen from mirrow.tensorflow.org mirror

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -42,7 +42,7 @@ $(eval $(call addlib_s,libeigen,$(CONFIG_LIBEIGEN)))
 LIBEIGEN_COMMIT=049af2f56331
 LIBEIGEN_PATCHDIR=$(LIBEIGEN_BASE)/patches
 
-LIBEIGEN_URL=https://bitbucket.org/eigen/eigen/get/${LIBEIGEN_COMMIT}.tar.gz
+LIBEIGEN_URL=https://storage.googleapis.com/mirror.tensorflow.org/bitbucket.org/eigen/eigen/get/${LIBEIGEN_COMMIT}.tar.gz
 $(eval $(call fetch,libeigen,$(LIBEIGEN_URL)))
 $(eval $(call patch,libeigen,$(LIBEIGEN_PATCHDIR),eigen-eigen-$(LIBEIGEN_COMMIT)))
 


### PR DESCRIPTION
libeigen has shifted from bitbucket to gitlab. 
However, I wasn't able to find a method to fetch specific commit tars from gitlab.
Instead, this mirror from tensorflow.org works