### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "eigen"
+description := "A C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms."
+gitrepo     := "https://gitlab.com/libeigen/eigen.git"
+homepage    := "http://eigen.tuxfamily.org/"
+version     := 049af2f56331 sha256:f3d69ac773ecaf3602cb940040390d4e71a501bb145ca9e01ce5464cf6d4eb68 http://mirror.tensorflow.org/bitbucket.org/eigen/eigen/get/049af2f56331.tar.gz
+license     := "MPL-2.0"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

